### PR TITLE
Add dependency to python-cairo

### DIFF
--- a/install-archlinux
+++ b/install-archlinux
@@ -27,6 +27,7 @@ depends+=('python-httplib2')
 depends+=('python-psutil')
 depends+=('python-dateutil')
 depends+=('python-pymongo')
+depends+=('python-cairo')
 
 optdepends=()
 optdepends+=('python-dateutil')


### PR DESCRIPTION
Without this dependency, the application can't render the calendar.