### PR TITLE
fix issue on version numbering for building on Arch Linux

### DIFF
--- a/install-archlinux
+++ b/install-archlinux
@@ -14,7 +14,7 @@ fi
 pkgName=starcal3
 sourceDir="`dirname \"$myPath\"`"
 #"$sourceDir/scripts/assert_python3"
-version=`$sourceDir/scal3/get_version.py`
+version=`$sourceDir/scal3/get_version.py | sed 's/\-/_/g'`
 
 tmpDir=/tmp/$pkgName-install-arch
 mkdir -p $tmpDir


### PR DESCRIPTION
Package version (`$pkgver` variable in build file) must avoid to use
hyphen and space symbols. This commit replace all hyphen on package
version which has been generated based on git tags with an underscore.
Because I don't know rules of making packages on other distributions, I
just edit build file of Arch.